### PR TITLE
Reduce memory usage

### DIFF
--- a/library/src/main/java/com/daasuu/library/FPSSurfaceView.java
+++ b/library/src/main/java/com/daasuu/library/FPSSurfaceView.java
@@ -29,6 +29,7 @@ public class FPSSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
     private SurfaceHolder mSurfaceHolder;
 
     private List<DisplayBase> mDisplayList = new ArrayList<>();
+    private final List<DisplayBase> mDrawingList = new ArrayList<>();
 
     public FPSSurfaceView(Context context) {
         this(context, null, 0);
@@ -99,19 +100,19 @@ public class FPSSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
 
         synchronized (this) {
 
-            List<DisplayBase> copyDisplayBaseList = new ArrayList<DisplayBase>(mDisplayList);
-
             Canvas canvas = mSurfaceHolder.lockCanvas();
             if (canvas == null) return;
 
             canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
 
-            for (DisplayBase DisplayBase : copyDisplayBaseList) {
+            mDrawingList.addAll(mDisplayList);
+            for (DisplayBase DisplayBase : mDrawingList) {
                 if (DisplayBase == null) {
                     continue;
                 }
                 DisplayBase.draw(canvas);
             }
+            mDrawingList.clear();
 
             mSurfaceHolder.unlockCanvasAndPost(canvas);
         }

--- a/library/src/main/java/com/daasuu/library/FPSTextureView.java
+++ b/library/src/main/java/com/daasuu/library/FPSTextureView.java
@@ -25,6 +25,7 @@ public class FPSTextureView extends TextureView implements TextureView.SurfaceTe
     private int mFps = Constant.DEFAULT_FPS;
 
     private List<DisplayBase> mDisplayList = new ArrayList<>();
+    private final List<DisplayBase> mDrawingList = new ArrayList<>();
 
     public FPSTextureView(Context context) {
         this(context, null, 0);
@@ -90,20 +91,19 @@ public class FPSTextureView extends TextureView implements TextureView.SurfaceTe
     private void onTick() {
 
         synchronized (this) {
-
-            List<DisplayBase> copyDisplayObjectList = new ArrayList<DisplayBase>(mDisplayList);
-
             Canvas canvas = this.lockCanvas();
             if (canvas == null) return;
 
             canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
 
-            for (DisplayBase displayBase : copyDisplayObjectList) {
+            mDrawingList.addAll(mDisplayList);
+            for (DisplayBase displayBase : mDrawingList) {
                 if (displayBase == null) {
                     continue;
                 }
                 displayBase.draw(canvas);
             }
+            mDrawingList.clear();
 
             this.unlockCanvasAndPost(canvas);
         }

--- a/library/src/main/java/com/daasuu/library/drawer/BitmapDrawer.java
+++ b/library/src/main/java/com/daasuu/library/drawer/BitmapDrawer.java
@@ -41,6 +41,11 @@ public class BitmapDrawer extends BaseDrawer {
      */
     private Rect mBitmapRect;
 
+    /**
+     * The rectangle that the bitmap will be scaled/translated to fit into
+     */
+    private RectF mDpSizeRect;
+
     public BitmapDrawer(@NonNull Bitmap bitmap) {
         super(new Paint());
         this.mBitmap = bitmap;
@@ -57,6 +62,7 @@ public class BitmapDrawer extends BaseDrawer {
         mBitmapDpWidth = Util.convertPixelsToDp(mBitmap.getWidth(), context);
         mBitmapDpHeight = Util.convertPixelsToDp(mBitmap.getHeight(), context);
         mBitmapRect = new Rect(0, 0, mBitmap.getWidth(), mBitmap.getHeight());
+        mDpSizeRect = new RectF();
         return this;
     }
 
@@ -107,13 +113,13 @@ public class BitmapDrawer extends BaseDrawer {
         }
 
         if (mDpSize) {
-            RectF dpSizeRect = new RectF(
+            mDpSizeRect.set(
                     x,
                     y,
                     x + mBitmapDpWidth,
                     y + mBitmapDpHeight
             );
-            canvas.drawBitmap(mBitmap, mBitmapRect, dpSizeRect, mPaint);
+            canvas.drawBitmap(mBitmap, mBitmapRect, mDpSizeRect, mPaint);
         } else {
             canvas.drawBitmap(mBitmap, x, y, mPaint);
         }

--- a/library/src/main/java/com/daasuu/library/drawer/SpriteSheetDrawer.java
+++ b/library/src/main/java/com/daasuu/library/drawer/SpriteSheetDrawer.java
@@ -45,6 +45,16 @@ public class SpriteSheetDrawer extends BaseDrawer {
     private SpriteSheet mSpriteSheet;
 
     /**
+     * The subset of the SpriteSheet bitmap to be drawn
+     */
+    private final Rect mBitmapRect;
+
+    /**
+     * The rectangle that the SpriteSheet bitmap will be scaled/translated to fit into
+     */
+    private final Rect mBounds;
+
+    /**
      * member variables needed to skip a tick in mFrequency
      */
     private int mDrawingNum = Constant.DEFAULT_DRAWING_NUM;
@@ -96,6 +106,8 @@ public class SpriteSheetDrawer extends BaseDrawer {
         super(new Paint());
         this.mBitmap = bitmap;
         this.mSpriteSheet = spriteSheet;
+        mBitmapRect = new Rect();
+        mBounds = new Rect();
     }
 
 
@@ -219,27 +231,27 @@ public class SpriteSheetDrawer extends BaseDrawer {
         if (mBitmap == null) return;
 
         updateSpriteFrame();
-        Rect bitmapRect = new Rect((int) (mSpriteSheet.dx), (int) (mSpriteSheet.dy), (int) (mSpriteSheet.dx + mSpriteSheet.frameWidth), (int) (mSpriteSheet.dy + mSpriteSheet.frameHeight));
+        mBitmapRect.set((int) (mSpriteSheet.dx), (int) (mSpriteSheet.dy), (int) (mSpriteSheet.dx + mSpriteSheet.frameWidth), (int) (mSpriteSheet.dy + mSpriteSheet.frameHeight));
 
         if (mDpSize) {
 
-            Rect bounds = new Rect(
+            mBounds.set(
                     (int) x,
                     (int) y,
                     (int) (x + mBitmapDpWidth),
                     (int) (y + mBitmapDpHeight)
             );
-            canvas.drawBitmap(mBitmap, bitmapRect, bounds, mPaint);
+            canvas.drawBitmap(mBitmap, mBitmapRect, mBounds, mPaint);
 
         } else {
 
-            Rect bounds = new Rect(
+            mBounds.set(
                     (int) x,
                     (int) y,
                     (int) (x + mSpriteSheet.frameWidth),
                     (int) (y + mSpriteSheet.frameHeight)
             );
-            canvas.drawBitmap(mBitmap, bitmapRect, bounds, mPaint);
+            canvas.drawBitmap(mBitmap, mBitmapRect, mBounds, mPaint);
         }
 
     }


### PR DESCRIPTION
changes to avoid generating instance in a method which is executed at a high frequency. (such as `FPSTextureView.onTick()` or `Drawer.draw()` )
