### PR TITLE
Stop drawing if bmp has been recycled or DisplayBase is removed.

### DIFF
--- a/library/src/main/java/com/daasuu/library/Container.java
+++ b/library/src/main/java/com/daasuu/library/Container.java
@@ -99,11 +99,12 @@ public class Container extends DisplayBase {
     /**
      * Removes the specified child from the display list.
      *
-     * @param DisplayObject DisplayObject
+     * @param displayObject DisplayObject
      * @return this
      */
-    public Container removeChild(@NonNull DisplayObject DisplayObject) {
-        mDisplayList.remove(DisplayObject);
+    public Container removeChild(@NonNull DisplayObject displayObject) {
+        displayObject.disable();
+        mDisplayList.remove(displayObject);
         return this;
     }
 
@@ -114,7 +115,10 @@ public class Container extends DisplayBase {
      * @return this
      */
     public Container removeChildAt(int location) {
-        mDisplayList.remove(location);
+        DisplayBase removed = mDisplayList.remove(location);
+        if (removed != null) {
+            removed.disable();
+        }
         return this;
     }
 

--- a/library/src/main/java/com/daasuu/library/DisplayBase.java
+++ b/library/src/main/java/com/daasuu/library/DisplayBase.java
@@ -20,12 +20,17 @@ public abstract class DisplayBase {
 
     protected Drawer mDrawer;
 
+    private boolean mIsEnable;
+
     /**
      * call from FPSTextureView or FPSSurfaceView when it is addChild.
      *
      * @param fps Set in FPSTextureView or FPSSurfaceView.
      */
     void setUp(long fps) {
+        synchronized (this) {
+            mIsEnable = true;
+        }
         mAnimator.setUp(fps);
     }
 
@@ -60,9 +65,13 @@ public abstract class DisplayBase {
      * @param canvas This Canvas acquired by lookCanvas in FPSTextureView or FPSSurfaceView.
      */
     void draw(@NonNull Canvas canvas) {
-        mAnimator.setBaseLine(canvas, mDrawer.getWidth(), mDrawer.getHeight());
-        mAnimator.updateAnimParam(mAnimParameter);
-        mDrawer.draw(canvas, mAnimParameter.x, mAnimParameter.y, mAnimParameter.alpha, mAnimParameter.scaleX, mAnimParameter.scaleY, mAnimParameter.rotation);
+        synchronized (this) {
+            if (mIsEnable) {
+                mAnimator.setBaseLine(canvas, mDrawer.getWidth(), mDrawer.getHeight());
+                mAnimator.updateAnimParam(mAnimParameter);
+                mDrawer.draw(canvas, mAnimParameter.x, mAnimParameter.y, mAnimParameter.alpha, mAnimParameter.scaleX, mAnimParameter.scaleY, mAnimParameter.rotation);
+            }
+        }
     }
 
     public AnimParameter getAnimParameter() {
@@ -85,6 +94,16 @@ public abstract class DisplayBase {
      */
     public boolean isPause() {
         return mAnimator.isPause();
+    }
+
+    /**
+     * disable this display object.
+     * This call from FPSTextureView, FPSSurfaceView or Container when it is removeChild.
+     */
+    void disable() {
+        synchronized (this) {
+            mIsEnable = false;
+        }
     }
 
     /**

--- a/library/src/main/java/com/daasuu/library/FPSSurfaceView.java
+++ b/library/src/main/java/com/daasuu/library/FPSSurfaceView.java
@@ -161,11 +161,12 @@ public class FPSSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
     /**
      * Removes the specified child from the display list.
      *
-     * @param DisplayBase DisplayBase2
+     * @param displayBase DisplayBase2
      * @return this
      */
-    public FPSSurfaceView removeChild(@NonNull DisplayBase DisplayBase) {
-        mDisplayList.remove(DisplayBase);
+    public FPSSurfaceView removeChild(@NonNull DisplayBase displayBase) {
+        displayBase.disable();
+        mDisplayList.remove(displayBase);
         return this;
     }
 
@@ -176,7 +177,10 @@ public class FPSSurfaceView extends SurfaceView implements SurfaceHolder.Callbac
      * @return this
      */
     public FPSSurfaceView removeChildAt(int location) {
-        mDisplayList.remove(location);
+        DisplayBase removed = mDisplayList.remove(location);
+        if (removed != null) {
+            removed.disable();
+        }
         return this;
     }
 

--- a/library/src/main/java/com/daasuu/library/FPSTextureView.java
+++ b/library/src/main/java/com/daasuu/library/FPSTextureView.java
@@ -170,6 +170,7 @@ public class FPSTextureView extends TextureView implements TextureView.SurfaceTe
      * @return this
      */
     public FPSTextureView removeChild(@NonNull DisplayBase displayBase) {
+        displayBase.disable();
         boolean a = mDisplayList.remove(displayBase);
         return this;
     }
@@ -181,7 +182,10 @@ public class FPSTextureView extends TextureView implements TextureView.SurfaceTe
      * @return this
      */
     public FPSTextureView removeChildAt(int location) {
-        mDisplayList.remove(location);
+        DisplayBase removed = mDisplayList.remove(location);
+        if (removed != null) {
+            removed.disable();
+        }
         return this;
     }
 

--- a/library/src/main/java/com/daasuu/library/drawer/BitmapDrawer.java
+++ b/library/src/main/java/com/daasuu/library/drawer/BitmapDrawer.java
@@ -106,6 +106,11 @@ public class BitmapDrawer extends BaseDrawer {
             return;
         }
 
+        if (mBitmap.isRecycled()) {
+            mBitmap = null;
+            return;
+        }
+
         if (mDpSize) {
             RectF dpSizeRect = new RectF(
                     x,

--- a/library/src/main/java/com/daasuu/library/drawer/SpriteSheetDrawer.java
+++ b/library/src/main/java/com/daasuu/library/drawer/SpriteSheetDrawer.java
@@ -218,6 +218,11 @@ public class SpriteSheetDrawer extends BaseDrawer {
     protected void draw(Canvas canvas, float x, float y) {
         if (mBitmap == null) return;
 
+        if (mBitmap.isRecycled()) {
+            mBitmap = null;
+            return;
+        }
+
         updateSpriteFrame();
         Rect bitmapRect = new Rect((int) (mSpriteSheet.dx), (int) (mSpriteSheet.dy), (int) (mSpriteSheet.dx + mSpriteSheet.frameWidth), (int) (mSpriteSheet.dy + mSpriteSheet.frameHeight));
 


### PR DESCRIPTION
I fixed 2 points.
First fix point is to stop drawing when bitmap has been recycled.
Second, stop drawing when DisplayBase is removed from FPSTextureView, SurfaceView or Container.
